### PR TITLE
Fix badge bug

### DIFF
--- a/redux/actions/index.tsx
+++ b/redux/actions/index.tsx
@@ -235,14 +235,15 @@ export function addBadge(UserId: number, badge: Badge) {
     })
       .then(res => {
         if (res.status >= 400) throw new Error("Sorry, can't award you this badge");
-        res.json();
+        return res.json();
       })
-      .then(res =>
+      .then(res => {
+        console.log(res);
         dispatch({
           type: 'ADD_BADGE',
           payload: [res],
         })
-      )
+      })
       .catch(error => console.log('Cannot, sorry: ', error));
   };
 }

--- a/redux/actions/index.tsx
+++ b/redux/actions/index.tsx
@@ -237,13 +237,12 @@ export function addBadge(UserId: number, badge: Badge) {
         if (res.status >= 400) throw new Error("Sorry, can't award you this badge");
         return res.json();
       })
-      .then(res => {
-        console.log(res);
+      .then(res =>
         dispatch({
           type: 'ADD_BADGE',
           payload: [res],
         })
-      })
+      )
       .catch(error => console.log('Cannot, sorry: ', error));
   };
 }


### PR DESCRIPTION
Closes #32 : fetch wasn't returning, causing undefined to be inserted into the user's badges